### PR TITLE
Escapes regex special characters

### DIFF
--- a/Build/Archetypes/Sitecore-CD/Pipelines/1 Configure.pipeline/90 Deny Remote Access to Sitecore.xdt.disabled
+++ b/Build/Archetypes/Sitecore-CD/Pipelines/1 Configure.pipeline/90 Deny Remote Access to Sitecore.xdt.disabled
@@ -9,9 +9,9 @@
 		  <rules>
 				<!-- this rule will cause 404s if you try to access the Sitecore admin from anywhere but localhost - requires IIS rewrite module -->
 				<rule xdt:Transform="Insert" name="Deny remote access to admin" patternSyntax="ECMAScript" stopProcessing="true">
-					<match url="sitecore/(admin|login|shell)*" />
+					<match url="sitecore\/(admin|debug|login|shell)+" />
 					<conditions>
-						<add input="{REMOTE_ADDR}" pattern="127.0.0.1" negate="true" />
+						<add input="{{REMOTE_ADDR}}" pattern="127.0.0.1" negate="true" />
 					</conditions>
 					<action type="CustomResponse" statusCode="404" statusReason="Not Found" statusDescription="Not Found" />
 				</rule>


### PR DESCRIPTION
Enabling as-is doesn't produce expected xform values due to regex character escaping.
++ adds *debug* to url matching as per sitecore install guide recommendation